### PR TITLE
Change URIs of OAuth authorization server and scope name

### DIFF
--- a/FITChecker/src/main/java/cz/mpelant/fitchecker/auth/AuthorizationCodeInstalledCvut.java
+++ b/FITChecker/src/main/java/cz/mpelant/fitchecker/auth/AuthorizationCodeInstalledCvut.java
@@ -31,8 +31,8 @@ import java.net.URL;
 public class AuthorizationCodeInstalledCvut {
 
 
-    public static final String LOGIN_URL = "https://auth.fit.cvut.cz/oauth/login.do";
-    public static final String APPROVE_URL = "https://auth.fit.cvut.cz/oauth/oauth/authorize";
+    public static final String LOGIN_URL = "https://auth.fit.cvut.cz/login.do";
+    public static final String APPROVE_URL = "https://auth.fit.cvut.cz/oauth/authorize";
     public static final String CODE = "code";
     /**
      * Authorization code flow.

--- a/FITChecker/src/main/java/cz/mpelant/fitchecker/auth/OAuth.java
+++ b/FITChecker/src/main/java/cz/mpelant/fitchecker/auth/OAuth.java
@@ -39,7 +39,7 @@ public class OAuth {
     /**
      * OAuth 2 scope.
      */
-    private static final String SCOPE = "urn:ctu:oauth:kosapi:public.readonly";
+    private static final String SCOPE = "cvut:kosapi:read";
 
     /**
      * Global instance of the HTTP transport.
@@ -51,8 +51,8 @@ public class OAuth {
      */
     static final JsonFactory JSON_FACTORY = new AndroidJsonFactory();
 
-    private static final String TOKEN_SERVER_URL = "https://auth.fit.cvut.cz/oauth/oauth/token";
-    private static final String AUTHORIZATION_SERVER_URL = "https://auth.fit.cvut.cz/oauth/oauth/authorize";
+    private static final String TOKEN_SERVER_URL = "https://auth.fit.cvut.cz/oauth/token";
+    private static final String AUTHORIZATION_SERVER_URL = "https://auth.fit.cvut.cz/oauth/authorize";
 
 
     private static void deleteRecursively(File file){


### PR DESCRIPTION
This is not just URIs change, there’s a newer instance of OAAS on the new URIs with more strict configuration. I briefly checked the OAuth library you use and it should be okay, but before releasing, please check if it really works.
